### PR TITLE
Sui theme v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,24 @@
-> @schibstedspain/theme-basic is deprecated. Please use @schibstedspain/sui-theme instead.
-
-# SUI Components Basic Theme
+# SUI Components Theme
 
 This repository contains:
 
-* Generic variables to initialize default values and component styles
-* A set of placeholders ready to style your component (buttons, tabs, forms, grid system...)
-* Functions and mixins helpers
+* Generic variables to initialize default values and component styles.
+* A set of placeholders ready to style your component (buttons, tabs, forms, grid system...).
+* Functions and mixins helpers.
 
 ## Usage
 
-Import `theme-basic` into your sui-component including the path in `index.scss`:
+Import `sui-theme` into your sui-component including the path in `index.scss`:
 
 ```
-@import '../node_modules/@schibstedspain/theme-basic/src/index';
+@import '../node_modules/@schibstedspain/sui-theme/src/index';
 ```
 
-If you want to customize your components, create your own theme and add it to yor component just __before__ the theme-basic import.
+If you want to customize your components, create your own theme and add it to your component just __before__ the sui-theme import.
 
 ```
 @import '../custom-settings';
-@import '~@schibstedspain/theme-basic/src/index';
+@import '~@schibstedspain/sui-theme/src/index';
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ If you want to customize your components, create your own theme and add it to yo
 @import '~@schibstedspain/sui-theme/src/index';
 ```
 
+## Upgrade from theme-basic@7
+Compatibility variables are still available to import manually.
+
+**Import only what you need, in inheritance order**
+
+For instance:
+```
+@import '../custom-settings';
+@import '~@schibstedspain/sui-theme/src/settings-compat-v7/color';
+@import '~@schibstedspain/sui-theme/src/settings-compat-v7/spacing';
+@import '~@schibstedspain/sui-theme/src/index';
+```
+
+Find below de compat varible groups available:
+
+* [settings-compat-v7/color](https://github.com/SUI-Components/sui-theme/blob/master/src/settings-compat-v7/_color.scss)
+* [settings-compat-v7/font](https://github.com/SUI-Components/sui-theme/blob/master/src/settings-compat-v7/_font.scss)
+* [settings-compat-v7/spacing](https://github.com/SUI-Components/sui-theme/blob/master/src/settings-compat-v7/_spacing.scss)
+* [settings-compat-v7/box-style](https://github.com/SUI-Components/sui-theme/blob/master/src/settings-compat-v7/_box-style.scss)
+* [settings-compat-v7/animation](https://github.com/SUI-Components/sui-theme/blob/master/src/settings-compat-v7/_animation.scss)
+* [settings-compat-v7/layout](https://github.com/SUI-Components/sui-theme/blob/master/src/settings-compat-v7/_layout.scss)
 
 ## Update
 If you need to update any of these variables please pull request.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@schibstedspain/theme-basic",
+  "name": "@schibstedspain/sui-theme",
   "version": "7.28.0",
   "description": "Generic theme to add styles to all generic components",
   "main": "lib/index.scss",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@schibstedspain/sui-theme",
   "version": "7.28.0",
-  "description": "Generic theme to add styles to all generic components",
+  "description": "Generic theme to add styles to all SUI components",
   "main": "lib/index.scss",
   "scripts": {
     "clean:lib": "rimraf ./lib/*",
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SUI-Components/theme-basic.git"
+    "url": "git+https://github.com/SUI-Components/sui-theme.git"
   },
   "keywords": [
     "sass",
@@ -41,9 +41,9 @@
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/scm-spain/theme-basic/issues"
+    "url": "https://github.com/scm-spain/sui-theme/issues"
   },
-  "homepage": "https://github.com/scm-spain/theme-basic#readme",
+  "homepage": "https://github.com/scm-spain/sui-theme#readme",
   "devDependencies": {
     "@s-ui/lint": "2",
     "@s-ui/mono": "1",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/scm-spain/sui-theme/issues"
+    "url": "https://github.com/SUI-Components/sui-theme/issues"
   },
-  "homepage": "https://github.com/scm-spain/sui-theme#readme",
+  "homepage": "https://github.com/SUI-Components/sui-theme#readme",
   "devDependencies": {
     "@s-ui/lint": "2",
     "@s-ui/mono": "1",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   },
   "homepage": "https://github.com/scm-spain/theme-basic#readme",
   "devDependencies": {
-    "@schibstedspain/sui-lint": "2",
-    "@schibstedspain/sui-mono": "1",
-    "@schibstedspain/sui-precommit": "2",
+    "@s-ui/lint": "2",
+    "@s-ui/mono": "1",
+    "@s-ui/precommit": "2",
     "cpx": "1.5.0",
     "husky": "0.13.3",
     "rimraf": "2.5.4",
@@ -58,8 +58,8 @@
       "access": "public"
     },
     "validate-commit-msg": {
-      "types": "@schibstedspain/sui-mono/src/types"
+      "types": "@s-ui/mono/src/types"
     }
   },
-  "sasslintConfig": "./node_modules/@schibstedspain/sui-lint/sass-lint.yml"
+  "sasslintConfig": "./node_modules/@s-ui/lint/sass-lint.yml"
 }

--- a/src/_settings.scss
+++ b/src/_settings.scss
@@ -20,13 +20,6 @@
 // URLs
 $url-statics: '' !default;
 
-@import './settings-compat-v7/color';
-@import './settings-compat-v7/font';
-@import './settings-compat-v7/spacing';
-@import './settings-compat-v7/box-style';
-@import './settings-compat-v7/animation';
-@import './settings-compat-v7/layout';
-
 @import './settings/color';
 @import './settings/font';
 @import './settings/spacing';


### PR DESCRIPTION
New version of the theme only with "official" variables from new design.
This repo was rename to sui-theme and the NPM package renamed to schibstedspain/sui-theme