### PR TITLE
feat(settings): load font automatically

### DIFF
--- a/src/settings/_font.scss
+++ b/src/settings/_font.scss
@@ -6,8 +6,11 @@
 // * fz = font size
 // * lh = line height
 
+// Font family in case no font was defined
+$sui-theme-ff-sans-serif: 'Open Sans', Helvetica, sans-serif;
+
 // Font family
-$ff-sans-serif: 'Open Sans', Helvetica, sans-serif !default;
+$ff-sans-serif: $sui-theme-ff-sans-serif !default;
 
 // Font weights
 $fw-light: 300 !default;
@@ -46,3 +49,8 @@ $lh-m: $fz-m * 1.3 !default;
 $lh-s: $fz-s * 1.3 !default;
 $lh-xs: $fz-xs * 1.2 !default;
 $lh-xxs: $fz-xxs * 1.2 !default;
+
+// Loads font only if its default one
+@if($ff-sans-serif == $sui-theme-ff-sans-serif) {
+  @import url('https://fonts.googleapis.com/css?family=Open+Sans:#{$fw-light},#{$fw-regular},#{$fw-regular}i,#{$fw-semi-bold},#{$fw-bold},#{$fw-bold}i')
+}

--- a/src/settings/_font.scss
+++ b/src/settings/_font.scss
@@ -7,10 +7,11 @@
 // * lh = line height
 
 // Font family in case no font was defined
-$sui-theme-ff-sans-serif: 'Open Sans', Helvetica, sans-serif;
+$ff-open-sans: 'Open Sans', Helvetica, sans-serif;
+$ff-open-sans-import: true !default;
 
 // Font family
-$ff-sans-serif: $sui-theme-ff-sans-serif !default;
+$ff-sans-serif: $ff-open-sans !default;
 
 // Font weights
 $fw-light: 300 !default;
@@ -51,6 +52,7 @@ $lh-xs: $fz-xs * 1.2 !default;
 $lh-xxs: $fz-xxs * 1.2 !default;
 
 // Loads font only if its default one
-@if($ff-sans-serif == $sui-theme-ff-sans-serif) {
-  @import url('https://fonts.googleapis.com/css?family=Open+Sans:#{$fw-light},#{$fw-regular},#{$fw-regular}i,#{$fw-semi-bold},#{$fw-bold},#{$fw-bold}i')
+@if($ff-open-sans-import == true and $ff-sans-serif == $ff-open-sans) {
+  @import url('https://fonts.googleapis.com/css?family=Open+Sans:#{$fw-light},#{$fw-regular},#{$fw-regular}i,#{$fw-semi-bold},#{$fw-bold},#{$fw-bold}i');
+  $ff-open-sans-import: false !global;
 }


### PR DESCRIPTION
Load fonts from scss

Reasons:
* Theme takes control of how to load its front
* Weight to load are not hardcoded but defined by fw-* variables that could be modified by other themes that inherits
* The font is loaded **as first line of the css**, not on a seprated tag.
* Avoids special config in studios of projects
