### PR TITLE
add strip unit to compat font

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,8 +1,8 @@
+// Utils
+@import './utils';
 // Settings
 @import './settings-compat-v7/index';
 @import './settings';
-// Utils
-@import './utils';
 // Default styles
 @import './default';
 // Typography

--- a/src/settings-compat-v7/_font.scss
+++ b/src/settings-compat-v7/_font.scss
@@ -5,12 +5,12 @@ $fw-semi-bold: 600 !default;
 
 // Font sizes
 $fz-base: 14 !default;
-$fz-body: $fz-base * 1px !default;
-$fz-xs: ceil($fz-base * .666) * 1px !default;
-$fz-s: ceil($fz-base * .8) * 1px !default;
-$fz-m: $fz-base * 1px !default;
-$fz-l: ceil($fz-base * 1.25) * 1px !default;
-$fz-xl: ceil($fz-base * 1.75) * 1px !default;
+$fz-body: strip-unit($fz-base) * 1px !default;
+$fz-xs: strip-unit($ceil($fz-base * .666)) * 1px !default;
+$fz-s: strip-unit(ceil($fz-base * .8)) * 1px !default;
+$fz-m: strip-unit($fz-base) * 1px !default;
+$fz-l: strip-unit(ceil($fz-base * 1.25)) * 1px !default;
+$fz-xl: strip-unit(ceil($fz-base * 1.75)) * 1px !default;
 
 // Font sizes for headings
 $fz-h1: 32px !default;

--- a/src/utils.scss
+++ b/src/utils.scss
@@ -7,3 +7,4 @@
 @import './utils/text';
 @import './utils/url';
 @import './utils/colors';
+@import './utils/numbers';

--- a/src/utils/_numbers.scss
+++ b/src/utils/_numbers.scss
@@ -1,0 +1,13 @@
+// --- Numbers --- //
+
+// Remove the unit of a length
+// @param {Number} $number - Number to remove unit from
+// @return {Number} - Unitless number
+
+@function strip-unit($number) {
+  @if type-of($number) == 'number' and not unitless($number) {
+    @return $number / ($number * 0 + 1);
+  }
+
+  @return $number;
+}


### PR DESCRIPTION
This definition used in `src/settings-compat-v7/_font.scss` worked fine in V7:
```scss
$fz-base: 14
$fz-body: $fz-base * 1px !default; // 14px
```

but, since V8 has units, the compiler breaks trying to calculate the operation:
```scss
$fz-base: 14px
$fz-body: $fz-base * 1px !default; // ERROR:  14px*px isn't a valid CSS value.
```

To solve this, we decided to add a `strip-unit` function in order to be able to define `$fz-base` with or without units:

```scss
$fz-base: 14px
$fz-body: strip-unit($fz-base) * 1px !default; // 14px
```

```scss
$fz-base: 14
$fz-body: strip-unit($fz-base) * 1px !default; // 14px
```
 otherwise we can't define font sizes with units (as in sui-theme V8) in mt-theme.