### PR TITLE
add spacing comented values

### DIFF
--- a/src/settings-compat-v7/_spacing.scss
+++ b/src/settings-compat-v7/_spacing.scss
@@ -1,31 +1,31 @@
 // Margins
 $m-base: 16px !default;
-$m-v: ceil($m-base / 2) !default;
-$m-h: $m-base !default;
-$m-v-xsmall: ceil($m-v / 3) !default;
-$m-h-xsmall: ceil($m-h / 3) !default;
-$m-v-small: ceil($m-v / 2) !default;
-$m-h-small: ceil($m-h / 2) !default;
-$m-v-large: ceil($m-v * 2) !default;
-$m-h-large: ceil($m-h * 2) !default;
-$m-v-xlarge: ceil($m-v * 3) !default;
-$m-h-xlarge: ceil($m-h * 3) !default;
+$m-v: ceil($m-base / 2) !default;         // 8px
+$m-h: $m-base !default;                   // 16px
+$m-v-xsmall: ceil($m-v / 3) !default;     // 3px
+$m-h-xsmall: ceil($m-h / 3) !default;     // 6px
+$m-v-small: ceil($m-v / 2) !default;      // 4px
+$m-h-small: ceil($m-h / 2) !default;      // 8px
+$m-v-large: ceil($m-v * 2) !default;      // 16px
+$m-h-large: ceil($m-h * 2) !default;      // 32px
+$m-v-xlarge: ceil($m-v * 3) !default;     // 24px
+$m-h-xlarge: ceil($m-h * 3) !default;     // 48px
 
 // Paddings
 $p-base: 16px !default;
-$p-small: ceil($p-base / 2) !default;
-$p-xsmall: ceil($p-base / 3) !default;
-$p-xxsmall: ceil($p-base / 4) !default;
-$p-v: ceil($p-base / 2) !default;
-$p-h: $p-base !default;
-$p-v-xsmall: ceil($p-v / 3) !default;
-$p-h-xsmall: ceil($p-h / 3) !default;
-$p-v-small: ceil($p-v / 2) !default;
-$p-h-small: ceil($p-h / 2) !default;
-$p-v-large: ceil($p-v * 2) !default;
-$p-h-large: ceil($p-h * 2) !default;
-$p-v-xlarge: ceil($p-v * 3) !default;
-$p-h-xlarge: ceil($p-h * 3) !default;
+$p-small: ceil($p-base / 2) !default;     // 8px
+$p-xsmall: ceil($p-base / 3) !default;    // 6px
+$p-xxsmall: ceil($p-base / 4) !default;   // 4px
+$p-v: ceil($p-base / 2) !default;         // 8px
+$p-h: $p-base !default;                   // 16px
+$p-v-xsmall: ceil($p-v / 3) !default;     // 3px
+$p-h-xsmall: ceil($p-h / 3) !default;     // 6px
+$p-v-small: ceil($p-v / 2) !default;      // 4px
+$p-h-small: ceil($p-h / 2) !default;      // 8px
+$p-v-large: ceil($p-v * 2) !default;      // 16px
+$p-h-large: ceil($p-h * 2) !default;      // 32px
+$p-v-xlarge: ceil($p-v * 3) !default;     // 24px
+$p-h-xlarge: ceil($p-h * 3) !default;     // 48px
 
 // Gutter
 $gutter: $p-base !default;

--- a/src/settings/_spacing.scss
+++ b/src/settings/_spacing.scss
@@ -8,26 +8,26 @@
 // * p = padding
 
 // Paddings
-$p-base: 8px;                 // 8px
+$p-base: 8px;                    // 8px
 
-$p-giant: $p-base*6 !default; // 48px
-$p-xxxl: $p-base*5 !default;  // 40px
-$p-xxl: $p-base*4 !default;   // 32px
-$p-xl: $p-base*3 !default;    // 24px
-$p-m: $p-base !default;       // 8px
-$p-l: $p-base*2 !default;     // 16px
-$p-s: $p-base/2 !default;     // 4px
+$p-giant: $p-base * 6 !default; // 48px
+$p-xxxl: $p-base * 5 !default;  // 40px
+$p-xxl: $p-base * 4 !default;   // 32px
+$p-xl: $p-base * 3 !default;    // 24px
+$p-l: $p-base * 2 !default;     // 16px
+$p-m: $p-base !default;         // 8px
+$p-s: $p-base / 2 !default;     // 4px
 
 // Margins
-$m-base: 8px;                 // 8px
+$m-base: 8px;                   // 8px
 
-$m-giant: $m-base*6 !default; // 48px
-$m-xxxl: $m-base*5 !default;  // 40px
-$m-xxl: $m-base*4 !default;   // 32px
-$m-xl: $m-base*3 !default;    // 24px
-$m-m: $m-base !default;       // 8px
-$m-l: $m-base*2 !default;     // 16px
-$m-s: $m-base/2 !default;     // 4px
+$m-giant: $m-base * 6 !default; // 48px
+$m-xxxl: $m-base * 5 !default;  // 40px
+$m-xxl: $m-base * 4 !default;   // 32px
+$m-xl: $m-base * 3 !default;    // 24px
+$m-l: $m-base * 2 !default;     // 16px
+$m-m: $m-base !default;         // 8px
+$m-s: $m-base / 2 !default;     // 4px
 
 
 // Gutter


### PR DESCRIPTION
- Adding spacing compat values as a comment.  The reason for that is easily identify values when updating to new naming variables.

- fix linting errors in spacing operators