### PR TITLE
fix height items for grow lists on ie

### DIFF
--- a/src/utils/_list.scss
+++ b/src/utils/_list.scss
@@ -4,9 +4,7 @@
 // @include sui-list('grow');
 
 @mixin sui-list-gutter {
-  &:not(:last-child) {
-    margin-right: $m-list-gutter;
-  }
+  margin-left: $m-list-gutter;
 }
 
 @mixin sui-list($type: 'block'){
@@ -15,6 +13,8 @@
 
   @if $type == 'block' {
     flex-direction: column;
+  } @else if $type == 'inline' or $type == 'grow' {
+    margin-left: -$m-list-gutter;
   }
 
   &-item {


### PR DESCRIPTION
I've changed the gutter approach for `inline` and `grow` lists types.

Why?
Until now, we have a gutter as a `margin-right` for all items of the list **except the last one**. That made that the last item of the list had a bigger height in IE. I've fixed it changing `margin-right` for `margin-left` **for all elements** and put that gutter value as negative margin for the list. 