### PR TITLE
Inherit font family for some elements instead overwriting

### DIFF
--- a/src/components/_button.scss
+++ b/src/components/_button.scss
@@ -18,7 +18,7 @@
   border-radius: $bdrs-button;
   cursor: pointer;
   display: flex;
-  font-family: $ff-sans-serif;
+  font-family: inherit;
   line-height: $lh-button;
   outline: none;
   padding: $p-v $p-h;

--- a/src/components/_input.scss
+++ b/src/components/_input.scss
@@ -15,7 +15,7 @@
   border-radius: $bdrs-input;
   box-shadow: $bd-input;
   color: $c-input;
-  font-family: $ff-sans-serif;
+  font-family: inherit;
   font-weight: $fw-light;
   line-height: $lh-input;
   outline: none;

--- a/src/components/_select.scss
+++ b/src/components/_select.scss
@@ -18,7 +18,7 @@
   border-radius: $bdrs-base;
   box-shadow: $bd-select;
   display: inline-block;
-  font-family: $ff-sans-serif;
+  font-family: inherit;
   line-height: $lh-select;
   outline: none;
   padding: $p-v $p-h;


### PR DESCRIPTION
Please, review. Instead of overwriting the font-family, we just use inherit in order to keep consistency with the overall website. So, this will not fire the load of the font-face yet if not needed.