### PR TITLE
add dropdown vars

### DIFF
--- a/src/settings-compat-v7/_components.scss
+++ b/src/settings-compat-v7/_components.scss
@@ -180,6 +180,7 @@ $c-cookie-banner-close-icon: $c-gray-dark !default;
 $c-cookie-banner-close-icon-hover: $c-gray !default;
 
 // Dropdown
+$c-dropdown-button-large: $c-text-base !default;
 $bdt-dropdown-menu: 1px solid $c-primary !default;
 $bgc-dropdown-button-hover: $c-white !default;
 $bgc-dropdown-menu-hover: $c-white !default;
@@ -196,6 +197,7 @@ $bg-dropdown-user-button: $c-gray !default;
 $bgc-dropdown-user: $c-white !default;
 $w-dropdown-user-avatar: 48px !default;
 $w-dropdown-user-text: 100px !default;
+$c-dropdown-user-text-large: $c-text-base !default;
 
 // Form Autocompleted
 $bd-form-autocompleted: 1px solid $c-gray !default;


### PR DESCRIPTION
Adding `$c-dropdown-button-large` and `$c-dropdown-user-text-large` in order to be able to define a motos black topbar.
NOTE: i'm not migrating all variables because there are shared variables between components.