### PR TITLE
fix(settings-compat-v7): setted var -base to a number with pixels

### DIFF
--- a/src/settings-compat-v7/_font.scss
+++ b/src/settings-compat-v7/_font.scss
@@ -14,7 +14,7 @@
 $fw-semi-bold: 600 !default;
 
 // Font sizes
-$fz-base: 14 !default;
+$fz-base: 14px !default;
 $fz-body: strip-unit($fz-base) * 1px !default;
 $fz-xs: strip-unit(ceil($fz-base * .666)) * 1px !default;
 $fz-s: strip-unit(ceil($fz-base * .8)) * 1px !default;


### PR DESCRIPTION
**What does this PR do?**
This PR has the main purpose of avoid font-size errors for missing measure type

**Any background context you can provide?**
If no one  is provided the font-size fails on some imports.