### PR TITLE
feat(META): remove compat variables by default

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,7 +1,6 @@
 // Utils
 @import './utils';
 // Settings
-@import './settings-compat-v7/index';
 @import './settings';
 // Default styles
 @import './default';


### PR DESCRIPTION
Refactor was done to make all components compatible with the change:

* https://github.com/SUI-Components/sui-components/pull/327
* https://github.schibsted.io/scmspain/frontend-fc--uilib-components/pull/196
* https://github.schibsted.io/scmspain/frontend-mt--uilib-components/pull/278

The plan is to merge first the above PRs, and afterwards publish this new version of sui-theme.

We can do a new major of sui-theme but it doesn't make really sense as sui-theme is loaded by centralized [sui-component-dependencies](https://github.com/SUI-Components/sui/blob/master/packages/sui-component-dependencies/package.json#L13)

No need to refactor NC or CF because they already add `@import '~@schibstedspain/sui-theme/lib/settings';` to have the new variables.




