### PR TITLE
refactor(utils): deprecated breakpoint mixins moved to deprecated file

### DIFF
--- a/src/utils.scss
+++ b/src/utils.scss
@@ -1,5 +1,6 @@
 // Utils
 @import './utils/breakpoints';
+@import './utils/breakpoints-deprecated';
 @import './utils/colors';
 @import './utils/forms';
 @import './utils/image';

--- a/src/utils/_breakpoints-deprecated.scss
+++ b/src/utils/_breakpoints-deprecated.scss
@@ -1,0 +1,56 @@
+// Breakpoint viewport sizes and media queries.
+//
+// Breakpoints are defined as a map of (name: minimum width), order from small to large:
+//
+//    (xxs: 0, xs: 320px, sm: 576px, md: 768px)
+
+// Name of the next breakpoint, or null for the last breakpoint.
+//
+//    >> breakpoint-next(sm)
+//    md
+@function breakpoint-next($name) {
+  $n: index($breakpoint-names, $name);
+  @return if($n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null);
+}
+
+// Maximum breakpoint width. Null for the largest (last) breakpoint.
+// The maximum value is calculated as the minimum of the next one less 0.1.
+//
+//    >> breakpoint-max(sm)
+//    767px
+@function breakpoint-max($name) {
+  $next: breakpoint-next($name);
+  @return if($next, breakpoint-min($next) - 1px, null);
+}
+
+// Media of at most the maximum breakpoint width. No query for the largest breakpoint.
+// Makes the @content apply to the given breakpoint and narrower.
+@mixin media-breakpoint-down($name) {
+  $max: breakpoint-max($name);
+  @if $max {
+    @media (max-width: $max) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+// Media that spans multiple breakpoint widths.
+// Makes the @content apply between the min and max breakpoints
+@mixin media-breakpoint-between($lower, $upper) {
+  @include media-breakpoint-up($lower) {
+    @include media-breakpoint-down($upper) {
+      @content;
+    }
+  }
+}
+
+// Media between the breakpoint's minimum and maximum widths.
+// No minimum for the smallest breakpoint, and no maximum for the largest one.
+// Makes the @content apply only to the given breakpoint, not viewports any wider or narrower.
+@mixin media-breakpoint-only($name) {
+  @include media-breakpoint-between($name, $name) {
+    @content;
+  }
+}

--- a/src/utils/_breakpoints.scss
+++ b/src/utils/_breakpoints.scss
@@ -4,15 +4,6 @@
 //
 //    (xxs: 0, xs: 320px, sm: 576px, md: 768px)
 
-// Name of the next breakpoint, or null for the last breakpoint.
-//
-//    >> breakpoint-next(sm)
-//    md
-@function breakpoint-next($name) {
-  $n: index($breakpoint-names, $name);
-  @return if($n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null);
-}
-
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.
 //
 //    >> breakpoint-min(sm)
@@ -20,16 +11,6 @@
 @function breakpoint-min($name) {
   $min: map-get($breakpoints, $name);
   @return if($min != 0, $min, null);
-}
-
-// Maximum breakpoint width. Null for the largest (last) breakpoint.
-// The maximum value is calculated as the minimum of the next one less 0.1.
-//
-//    >> breakpoint-max(sm)
-//    767px
-@function breakpoint-max($name) {
-  $next: breakpoint-next($name);
-  @return if($next, breakpoint-min($next) - 1px, null);
 }
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.
@@ -41,38 +22,6 @@
       @content;
     }
   } @else {
-    @content;
-  }
-}
-
-// Media of at most the maximum breakpoint width. No query for the largest breakpoint.
-// Makes the @content apply to the given breakpoint and narrower.
-@mixin media-breakpoint-down($name) {
-  $max: breakpoint-max($name);
-  @if $max {
-    @media (max-width: $max) {
-      @content;
-    }
-  } @else {
-    @content;
-  }
-}
-
-// Media that spans multiple breakpoint widths.
-// Makes the @content apply between the min and max breakpoints
-@mixin media-breakpoint-between($lower, $upper) {
-  @include media-breakpoint-up($lower) {
-    @include media-breakpoint-down($upper) {
-      @content;
-    }
-  }
-}
-
-// Media between the breakpoint's minimum and maximum widths.
-// No minimum for the smallest breakpoint, and no maximum for the largest one.
-// Makes the @content apply only to the given breakpoint, not viewports any wider or narrower.
-@mixin media-breakpoint-only($name) {
-  @include media-breakpoint-between($name, $name) {
     @content;
   }
 }


### PR DESCRIPTION
In order to avoid the future use of any breakpoint mixin != media-breakpoint-up, we are moving everything else to another file