### PR TITLE
feat(components): shared styles from atomInput

### DIFF
--- a/src/components/atom/input/_placeholders.scss
+++ b/src/components/atom/input/_placeholders.scss
@@ -1,0 +1,16 @@
+%sui-atom-input-input {
+  background: $c-white;
+  border: $bdw-s solid $c-gray-light;
+  box-sizing: border-box;
+  font-size: $fz-base;
+  height: $h-atom-input--m;
+  padding-left: $p-l;
+  padding-right: $p-l;
+  width: 100%;
+}
+
+%sui-atom-input-input-focus {
+  border: $bdw-s solid $c-primary;
+  box-shadow: $bxsh-focus;
+  outline: 0 none;
+}

--- a/src/components/atom/input/_settings.scss
+++ b/src/components/atom/input/_settings.scss
@@ -1,0 +1,8 @@
+$h-atom-input--m: 40px !default;
+$h-atom-input--s: 32px !default;
+
+$c-atom-input--success: $c-success !default;
+$c-atom-input--error: $c-error !default;
+
+$sizes-atom-input: m $h-atom-input--m, s $h-atom-input--s !default;
+$states-atom-input: success $c-atom-input--success, error $c-atom-input--error !default;

--- a/src/components/atom/input/index.scss
+++ b/src/components/atom/input/index.scss
@@ -1,0 +1,2 @@
+@import 'settings';
+@import 'placeholders';

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,6 +8,7 @@
 @import './typography';
 // Reset
 @import './reset';
+
 // Components
 @import './components/icon';
 @import './components/button';
@@ -17,6 +18,10 @@
 @import './components/tag';
 @import './components/card';
 @import './components/badge';
+
+// SUI-Components
+@import './components/atom/input/index';
+
 // Icons
 @import './icons/arrow';
 // Layout


### PR DESCRIPTION
In order to be able to share these styles with other componentes (`MoleculeInputTags`, `MoleculeSelect`,...) these styles should be moved to `sui-theme`