### PR TITLE
feat(components): min-height placeholder atom-input

### DIFF
--- a/src/components/atom/input/_placeholders.scss
+++ b/src/components/atom/input/_placeholders.scss
@@ -3,7 +3,7 @@
   border: $bdw-s solid $c-gray-light;
   box-sizing: border-box;
   font-size: $fz-base;
-  height: $h-atom-input--m;
+  min-height: $h-atom-input--m;
   padding-left: $p-l;
   padding-right: $p-l;
   width: 100%;


### PR DESCRIPTION
Better common placeholder for "input" components (`AtomInput`, `MoleculeInputTags`, `MoleculeSelect`) by setting a `min-height` instead of a `height`