### PR TITLE
feat(settings): add colors gradient sass variables

### DIFF
--- a/src/settings/_color.scss
+++ b/src/settings/_color.scss
@@ -18,35 +18,125 @@ $c-system: #000000 !default;
 
 // Primary color
 $c-primary: #2b91c1 !default;
+
+// Old primary color gradients, keeping them for retro compatibility
 $c-primary-light: color-variation($c-primary, $c-light-step) !default;
 $c-primary-dark: color-variation($c-primary, $c-dark-step) !default;
 
+// Primary color light gradients
+$c-primary-light-1: color-variation($c-primary, 1) !default;
+$c-primary-light-2: color-variation($c-primary, 2) !default;
+$c-primary-light-3: color-variation($c-primary, 3) !default;
+$c-primary-light-4: color-variation($c-primary, 4) !default;
+$c-primary-light-5: color-variation($c-primary, 5) !default;
+
+// Primary color dark gradients
+$c-primary-dark-1: color-variation($c-primary, -1) !default;
+$c-primary-dark-2: color-variation($c-primary, -2) !default;
+$c-primary-dark-3: color-variation($c-primary, -3) !default;
+$c-primary-dark-4: color-variation($c-primary, -4) !default;
+
 // Secondary/Accent color
 $c-accent: #d57c1b !default;
+
+// Old Secondary/Accent color gradients, keeping them for retro compatibility
 $c-accent-light: color-variation($c-accent, $c-light-step) !default;
 $c-accent-dark: color-variation($c-accent, $c-dark-step) !default;
 
+// Secondary/Accent color light gradients
+$c-accent-light-1: color-variation($c-accent, 1) !default;
+$c-accent-light-2: color-variation($c-accent, 2) !default;
+$c-accent-light-3: color-variation($c-accent, 3) !default;
+$c-accent-light-4: color-variation($c-accent, 4) !default;
+$c-accent-light-5: color-variation($c-accent, 5) !default;
+
+// Secondary/Accent color dark gradients
+$c-accent-dark-1: color-variation($c-accent, -1) !default;
+$c-accent-dark-2: color-variation($c-accent, -2) !default;
+$c-accent-dark-3: color-variation($c-accent, -3) !default;
+$c-accent-dark-4: color-variation($c-accent, -4) !default;
+
 // Gray color
 $c-gray: #777777 !default;
+
+// Old Gray color gradients, keeping them for retro compatibility
 $c-gray-light: color-variation($c-gray, $c-light-step) !default;
 $c-gray-dark: color-variation($c-gray, $c-dark-step) !default;
 $c-gray-lightest: color-variation($c-gray, 4) !default;
 
+// Gray color light gradients
+$c-gray-light-1: color-variation($c-gray, 1) !default;
+$c-gray-light-2: color-variation($c-gray, 2) !default;
+$c-gray-light-3: color-variation($c-gray, 3) !default;
+$c-gray-light-4: color-variation($c-gray, 4) !default;
+$c-gray-light-5: color-variation($c-gray, 5) !default;
+
+// Gray color dark gradients
+$c-gray-dark-1: color-variation($c-gray, -1) !default;
+$c-gray-dark-2: color-variation($c-gray, -2) !default;
+$c-gray-dark-3: color-variation($c-gray, -3) !default;
+$c-gray-dark-4: color-variation($c-gray, -4) !default;
+
 
 // Success color
 $c-success: #00a544 !default;
+
+// Old Success color gradients, keeping them for retro compatibility
 $c-success-light: color-variation($c-success, $c-light-step) !default;
 $c-success-dark: color-variation($c-success, $c-dark-step) !default;
 
+// Secondary/Accent color light gradients
+$c-success-light-1: color-variation($c-success, 1) !default;
+$c-success-light-2: color-variation($c-success, 2) !default;
+$c-success-light-3: color-variation($c-success, 3) !default;
+$c-success-light-4: color-variation($c-success, 4) !default;
+$c-success-light-5: color-variation($c-success, 5) !default;
+
+// Secondary/Accent color dark gradients
+$c-success-dark-1: color-variation($c-success, -1) !default;
+$c-success-dark-2: color-variation($c-success, -2) !default;
+$c-success-dark-3: color-variation($c-success, -3) !default;
+$c-success-dark-4: color-variation($c-success, -4) !default;
+
 // Alert color
 $c-alert: #ff6335 !default;
+
+// Old Alert color gradients, keeping them for retro compatibility
 $c-alert-light: color-variation($c-alert, $c-light-step) !default;
 $c-alert-dark: color-variation($c-alert, $c-dark-step) !default;
 
+// Alert color light gradients
+$c-alert-light-1: color-variation($c-alert, 1) !default;
+$c-alert-light-2: color-variation($c-alert, 2) !default;
+$c-alert-light-3: color-variation($c-alert, 3) !default;
+$c-alert-light-4: color-variation($c-alert, 4) !default;
+$c-alert-light-5: color-variation($c-alert, 5) !default;
+
+// Alert color dark gradients
+$c-alert-dark-1: color-variation($c-alert, -1) !default;
+$c-alert-dark-2: color-variation($c-alert, -2) !default;
+$c-alert-dark-3: color-variation($c-alert, -3) !default;
+$c-alert-dark-4: color-variation($c-alert, -4) !default;
+
 // Error color
 $c-error: #e93e40 !default;
+
+// Old Error Alert color gradients, keeping them for retro compatibility
 $c-error-light: color-variation($c-error, $c-light-step) !default;
 $c-error-dark: color-variation($c-error, $c-dark-step) !default;
+
+// Error color light gradients
+$c-error-light-1: color-variation($c-error, 1) !default;
+$c-error-light-2: color-variation($c-error, 2) !default;
+$c-error-light-3: color-variation($c-error, 3) !default;
+$c-error-light-4: color-variation($c-error, 4) !default;
+$c-error-light-5: color-variation($c-error, 5) !default;
+
+// Error color dark gradients
+$c-error-dark-1: color-variation($c-error, -1) !default;
+$c-error-dark-2: color-variation($c-error, -2) !default;
+$c-error-dark-3: color-variation($c-error, -3) !default;
+$c-error-dark-4: color-variation($c-error, -4) !default;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Specific Colors


### PR DESCRIPTION
Add colors gradient sass variables to have more customizable colors in the projects that are using sui-theme. It would make communication between UX/Devs easier standardizing and linking Zeplin designs with our sass color variables. It follows the following color gradation scheme:

![image](https://user-images.githubusercontent.com/1105226/52793121-45ac5080-306d-11e9-877e-d86829e8ab53.png)
