### PR TITLE
Adds xs size to AtomInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/sui-theme",
-  "version": "8.51.0",
+  "version": "8.51.1",
   "description": "Generic theme to add styles to all SUI components",
   "main": "lib/index.scss",
   "scripts": {

--- a/src/components/atom/input/_settings.scss
+++ b/src/components/atom/input/_settings.scss
@@ -1,5 +1,6 @@
 $h-atom-input--m: 40px !default;
 $h-atom-input--s: 32px !default;
+$h-atom-input--xs: 24px !default;
 
 $c-atom-input--success: $c-success !default;
 $c-atom-input--error: $c-error !default;


### PR DESCRIPTION
### PR Summary
We need to add an smaller size sass var to `atom-input` component.
Is backwards compatible with current implementation.

Avoids a bug in Firefox Browser when using with label:
![Screenshot 2019-08-02 at 11 31 23](https://user-images.githubusercontent.com/10925540/62360453-14d7af00-b519-11e9-9848-acedb0101b1c.png)
