### PR TITLE
feat(components): adds a missing xs size in atom input

### DIFF
--- a/src/components/atom/input/_settings.scss
+++ b/src/components/atom/input/_settings.scss
@@ -12,5 +12,5 @@ $bxsh-atom-input: $bxsh-focus !default;
 $bd-atom-input: $bdw-s solid $c-primary !default;
 $fz-atom-input: $fz-base !default;
 
-$sizes-atom-input: m $h-atom-input--m, s $h-atom-input--s !default;
+$sizes-atom-input: m $h-atom-input--m, xs $h-atom-input--xs, s $h-atom-input--s !default;
 $states-atom-input: success $c-atom-input--success, error $c-atom-input--error !default;


### PR DESCRIPTION
adds a missing `xs` size for AtomInput