### PR TITLE
fix(components): removes hardcoded value

### DIFF
--- a/src/components/atom/input/_placeholders.scss
+++ b/src/components/atom/input/_placeholders.scss
@@ -3,7 +3,6 @@
   border: $bdw-s solid $c-gray-light;
   box-sizing: border-box;
   font-size: $fz-atom-input;
-  min-height: $h-atom-input--m;
   padding-left: $pl-atom-input;
   padding-right: $pr-atom-input;
   width: 100%;


### PR DESCRIPTION
### PR Summary
The `min-height` value in `%sui-atom-input-input` class was overriding other modificator class values like `.sui-AtomInput-input-m`,
`.sui-AtomInput-input-s` and `.sui-AtomInput-input-xs` to apply.

Now, values defined by `$h-atom-input--m`, `$h-atom-input--s` or `$h-atom-input--xs` are just working ok:

**After fix:**
`min-height` value is determined by its size modificator class:
![Screenshot 2019-08-05 at 14 38 23](https://user-images.githubusercontent.com/10925540/62465338-ecf18100-b78e-11e9-9f19-21c101d6895c.png)

**Before fix**
Harcoded value was always applied:
![Screenshot 2019-08-05 at 14 42 40](https://user-images.githubusercontent.com/10925540/62465513-58d3e980-b78f-11e9-8af3-21001460ea86.png)

Please review