### PR TITLE
fix(utils): fix flex direction

### DIFF
--- a/src/utils/_list.scss
+++ b/src/utils/_list.scss
@@ -14,6 +14,7 @@
   @if $type == 'block' {
     flex-direction: column;
   } @else if $type == 'inline' or $type == 'grow' {
+    flex-direction: row;
     margin-left: -$m-list-gutter;
   }
 

--- a/src/utils/_list.scss
+++ b/src/utils/_list.scss
@@ -7,13 +7,13 @@
   margin-left: $m-list-gutter;
 }
 
-@mixin sui-list($type: 'block'){
+@mixin sui-list($type: 'block') {
   @include reset-list;
   display: flex;
 
   @if $type == 'block' {
     flex-direction: column;
-  } @else if $type == 'inline' or $type == 'grow' {
+  } @else {
     flex-direction: row;
     margin-left: -$m-list-gutter;
   }
@@ -25,8 +25,13 @@
     }
 
     @if $type == 'grow' {
-      flex: 1 1 100%;
       @include sui-list-gutter;
+      flex: 1 1 100%;
+    }
+
+    @if $type == 'grow-custom' {
+      @include sui-list-gutter;
+      @content;
     }
   }
 };


### PR DESCRIPTION
I've fixed flex direction and I've added a new list case:
for default, `grow` list is `flex: 1 1 100%;` but with `grow-custom` we can add a custom flex grow (p.e)