### PR TITLE
Fix/molecule select bd select sass var collision

### DIFF
--- a/src/components/_select.scss
+++ b/src/components/_select.scss
@@ -16,7 +16,7 @@
   background-color: $bgc-select;
   border: 0;
   border-radius: $bdrs-base;
-  box-shadow: $bd-select;
+  box-shadow: $bxsh-select;
   display: inline-block;
   font-family: inherit;
   line-height: $lh-select;
@@ -50,11 +50,11 @@
 
   &:hover {
     background-color: $bgc-select-hover;
-    box-shadow: $bd-select-hover;
+    box-shadow: $bxsh-select-hover;
   }
 
   &:focus {
     background-color: $bgc-select-focus;
-    box-shadow: $bd-select-focus;
+    box-shadow: $bxsh-select-focus;
   }
 }

--- a/src/settings-compat-v7/_components.scss
+++ b/src/settings-compat-v7/_components.scss
@@ -37,9 +37,9 @@ $bgc-select-icon-wrap: $c-gray-lightest !default;
 $p-select-icon-wrap: 0 $p-h-small !default;
 $w-select-icon-wrap: 30px !default;
 
-$bd-select: 0 0 0 1px $c-gray inset !default;
-$bd-select-hover: 0 0 0 1px $c-gray inset !default;
-$bd-select-focus: 0 0 0 1px $c-gray inset !default;
+$bxsh-select: 0 0 0 1px $c-gray inset !default;
+$bxsh-select-hover: 0 0 0 1px $c-gray inset !default;
+$bxsh-select-focus: 0 0 0 1px $c-gray inset !default;
 
 // --- Components --- //
 


### PR DESCRIPTION
After this fix no SASS var will override [the one recently added to molecule select](https://github.com/SUI-Components/sui-components/commit/ac9e0a818aced2e63f050b5618af8f6bca4fa27b#diff-9c56dc06633810faca5c9f5e5038701eR12) in an unwanted way. We already checked that this var is not used elsewhere across other verticals or sui components.