### PR TITLE
feat(settings): add new size variable $sz-icon-xxl

### DIFF
--- a/src/settings/_size.scss
+++ b/src/settings/_size.scss
@@ -8,3 +8,4 @@ $sz-icon-s: 16px !default;
 $sz-icon-m: 24px !default;
 $sz-icon-l: 32px !default;
 $sz-icon-xl: 40px !default;
+$sz-icon-xxl: 48px !default;


### PR DESCRIPTION
This new size variable would be useful for some use cases such as the AtomActionButton which requires 48px for its large size, 40px for its medium / default size and 32px for its small size.