### PR TITLE
feat(settings): add new secondary color

### DIFF
--- a/src/settings/_color.scss
+++ b/src/settings/_color.scss
@@ -38,10 +38,13 @@ $c-primary-dark-4: color-variation($c-primary, -4) !default;
 
 // Secondary/Accent color
 $c-accent: #d57c1b !default;
+$c-secondary: #d57c1b !default;
 
 // Old Secondary/Accent color gradients, keeping them for retro compatibility
 $c-accent-light: color-variation($c-accent, $c-light-step) !default;
 $c-accent-dark: color-variation($c-accent, $c-dark-step) !default;
+$c-secondary-light: color-variation($c-secondary, $c-light-step) !default;
+$c-secondary-dark: color-variation($c-secondary, $c-dark-step) !default;
 
 // Secondary/Accent color light gradients
 $c-accent-light-1: color-variation($c-accent, 1) !default;
@@ -49,12 +52,21 @@ $c-accent-light-2: color-variation($c-accent, 2) !default;
 $c-accent-light-3: color-variation($c-accent, 3) !default;
 $c-accent-light-4: color-variation($c-accent, 4) !default;
 $c-accent-light-5: color-variation($c-accent, 5) !default;
+$c-secondary-light-1: color-variation($c-secondary, 1) !default;
+$c-secondary-light-2: color-variation($c-secondary, 2) !default;
+$c-secondary-light-3: color-variation($c-secondary, 3) !default;
+$c-secondary-light-4: color-variation($c-secondary, 4) !default;
+$c-secondary-light-5: color-variation($c-secondary, 5) !default;
 
 // Secondary/Accent color dark gradients
 $c-accent-dark-1: color-variation($c-accent, -1) !default;
 $c-accent-dark-2: color-variation($c-accent, -2) !default;
 $c-accent-dark-3: color-variation($c-accent, -3) !default;
 $c-accent-dark-4: color-variation($c-accent, -4) !default;
+$c-secondary-dark-1: color-variation($c-secondary, -1) !default;
+$c-secondary-dark-2: color-variation($c-secondary, -2) !default;
+$c-secondary-dark-3: color-variation($c-secondary, -3) !default;
+$c-secondary-dark-4: color-variation($c-secondary, -4) !default;
 
 // Gray color
 $c-gray: #777777 !default;


### PR DESCRIPTION
## ⚽️ GOAL
This PR adds a new **sui-color** named `$c-secondary` and by default will have same color of `$c-accent`.

This option will allow other verticals to use in their defined secondary color in sui-components instead of overriding the component. 

So now, if we adapt our 'sui-components' to use this new color, we could use it like this: 

```javascript 
<AtomTooltip color="secondary" />
```

