### PR TITLE
Feat/add grid component config

### DIFF
--- a/src/utils.scss
+++ b/src/utils.scss
@@ -2,6 +2,7 @@
 @import './utils/breakpoints';
 @import './utils/colors';
 @import './utils/forms';
+@import './utils/grid';
 @import './utils/image';
 @import './utils/list';
 @import './utils/opacity';

--- a/src/utils/_grid.scss
+++ b/src/utils/_grid.scss
@@ -1,0 +1,30 @@
+// --- Grid --- //
+
+// Description:
+// Provide a color and step to get a lighter or darker color variation.
+// If step provided is bigger than the step variation limit the lighter or darker color available will be returned.
+
+// Usage:
+// $c-primary-light: color-variation($c-primary, 1) -> 1 step lighter
+// $c-primary-lighter: color-variation($c-primary, 2) -> 2 steps lighter
+// $c-primary-dark: color-variation($c-primary, -2) -> 2 steps darker
+// $c-primary-darkest: color-variation($c-primary, -4) -> 4 steps darker
+
+@mixin grid-flex-basis($size) {
+  flex-basis: (100% / $layout-grid-columns) * $size;
+}
+
+/*
+Example of use mixin
+
+.className {
+  @include grid-value(xs, 6); // Added a `xs` breakpoint, 6 columns
+  @include grid-value(l, 12); // Added a `l` breakpoint, 12 columns
+}
+*/
+
+@mixin grid-value($breakpoint-name, $size) {
+  @include media-breakpoint-up($breakpoint-name) {
+    @include grid-flex-basis($size);
+  }
+}

--- a/src/utils/_grid.scss
+++ b/src/utils/_grid.scss
@@ -13,8 +13,10 @@
 // @include grid-value(xs, 6); // Added a `xs` breakpoint, 6 columns
 // @include grid-value(sm, 12); // Added a `sm` breakpoint, 12 columns
 
+$grid-columns: 12;
+
 @mixin grid-flex-basis($columns) {
-  flex-basis: (100% / $layout-grid-columns) * $columns;
+  flex-basis: (100% / $grid-columns) * $columns;
 }
 
 @mixin grid-value($breakpoint-name, $columns) {

--- a/src/utils/_grid.scss
+++ b/src/utils/_grid.scss
@@ -6,19 +6,19 @@
 // Usage:
 
 // --- grid-flex-basis --- //
-// The $size is 12 columns based.
+// The $columns is 12 columns based.
 // @include grid-flex-basis(6); // Added a `6/12` columns of width.
 
 // --- grid-value --- //
 // @include grid-value(xs, 6); // Added a `xs` breakpoint, 6 columns
 // @include grid-value(sm, 12); // Added a `sm` breakpoint, 12 columns
 
-@mixin grid-flex-basis($size) {
-  flex-basis: (100% / $layout-grid-columns) * $size;
+@mixin grid-flex-basis($columns) {
+  flex-basis: (100% / $layout-grid-columns) * $columns;
 }
 
-@mixin grid-value($breakpoint-name, $size) {
+@mixin grid-value($breakpoint-name, $columns) {
   @include media-breakpoint-up($breakpoint-name) {
-    @include grid-flex-basis($size);
+    @include grid-flex-basis($columns);
   }
 }

--- a/src/utils/_grid.scss
+++ b/src/utils/_grid.scss
@@ -1,27 +1,21 @@
 // --- Grid --- //
 
 // Description:
-// Provide a color and step to get a lighter or darker color variation.
-// If step provided is bigger than the step variation limit the lighter or darker color available will be returned.
+// Provide a util mixins for generate your layout.
 
 // Usage:
-// $c-primary-light: color-variation($c-primary, 1) -> 1 step lighter
-// $c-primary-lighter: color-variation($c-primary, 2) -> 2 steps lighter
-// $c-primary-dark: color-variation($c-primary, -2) -> 2 steps darker
-// $c-primary-darkest: color-variation($c-primary, -4) -> 4 steps darker
+
+// --- grid-flex-basis --- //
+// The $size is 12 columns based.
+// @include grid-flex-basis(6); // Added a `6/12` columns of width.
+
+// --- grid-value --- //
+// @include grid-value(xs, 6); // Added a `xs` breakpoint, 6 columns
+// @include grid-value(sm, 12); // Added a `sm` breakpoint, 12 columns
 
 @mixin grid-flex-basis($size) {
   flex-basis: (100% / $layout-grid-columns) * $size;
 }
-
-/*
-Example of use mixin
-
-.className {
-  @include grid-value(xs, 6); // Added a `xs` breakpoint, 6 columns
-  @include grid-value(l, 12); // Added a `l` breakpoint, 12 columns
-}
-*/
 
 @mixin grid-value($breakpoint-name, $size) {
   @include media-breakpoint-up($breakpoint-name) {


### PR DESCRIPTION
# Add grid utils mixins

Move grid mixins to use with only SASS method. Based on Layout/Grid component.

https://github.com/SUI-Components/sui-components/pull/1295

**Example of use:**
```
// --- grid-value --- //
@include grid-value(xs, 6); // Added a `xs` breakpoint, 6 columns
@include grid-value(sm, 12); // Added a `sm` breakpoint, 12 columns
```