### PR TITLE
feat(utils): prevent gap with parent container

### DIFF
--- a/src/utils/_grid.scss
+++ b/src/utils/_grid.scss
@@ -23,8 +23,7 @@ $grid-columns: 12;
   display: flex;
   flex-wrap: wrap;
   list-style: none;
-  margin: 0 (-$gap / 2);
-  width: calc(100% + #{$gap});
+  margin: 0 (-$gap);
 }
 
 @mixin grid-flex-basis($columns) {


### PR DESCRIPTION
# Fix gap with parent container

Adjust spacing with parent container to fit correctly.

## Before
![image](https://user-images.githubusercontent.com/1427623/106458770-247adf80-6491-11eb-877a-e77f67d6b1e0.png)

## After

![image](https://user-images.githubusercontent.com/1427623/106459085-a10dbe00-6491-11eb-9ae8-3262ce516b3e.png)
