### PR TITLE
fix(settings): fix components using bdrs-none

### DIFF
--- a/src/settings/_box-style.scss
+++ b/src/settings/_box-style.scss
@@ -2,6 +2,7 @@
 
 // Border radius
 $bdrs-base: 8px !default;
+$bdrs-none: 0 !default;
 
 $bdrs-xxxl: $bdrs-base * 4 !default; // 32 px
 $bdrs-xxl: $bdrs-base * 2 !default; // 16 px


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Version `8.92.0` introduces a bug at components depending on the `bdrs-none` variable, p.ex. the `atom/table`

```
SassError: Undefined variable: "$bdrs-none".
        on line 6 of components/campaign/list/node_modules/@s-ui/react-atom-table/lib/index.scss
```

This PR restores the removed variable to fix the error.
